### PR TITLE
check_ssd_life: fix "[: unexpected operator"

### DIFF
--- a/check_ssd_life
+++ b/check_ssd_life
@@ -124,7 +124,7 @@ do
         exitstatus=$STATE_CRITICAL
         INFO="${INFO}(CRITICAL) "
     elif [ $VAL -lt $WARNING_THRESHOLD ];then
-        [ "$exitstatus" == $STATE_CRITICAL ] || exitstatus=$STATE_WARNING
+        [ "$exitstatus" = "$STATE_CRITICAL" ] || exitstatus=$STATE_WARNING
         INFO="${INFO}(WARNING) "
     else
         [ -n "$exitstatus" ] || exitstatus=$STATE_OK


### PR DESCRIPTION
Since we're using "/bin/sh" rather than "/bin/bash" using [ $1 == $2 ]
will error out since sh doesn't support `==`. Hence use a single `=`.